### PR TITLE
fix: prevent duplicate memory facts from being stored

### DIFF
--- a/apps/backend/internal/domain/handlers/loopback_dispatcher.go
+++ b/apps/backend/internal/domain/handlers/loopback_dispatcher.go
@@ -39,13 +39,14 @@ BEFORE making ANY memory modification:
    - Context that would help personalize future interactions
 
 4. **VERIFICATION STEP**: Before storing EACH fact:
-   - Use search_memory to check if this fact already exists
+   - Use search_memory(query=<keyword>, for_user=<participant_name>) to check if this fact already exists for that user
    - If found: SKIP this fact, do NOT add it again
    - If NOT found: proceed to add it
 
 5. When storing new facts:
-   - Call set_user_property for the user's own attributes (real name, phone, birthday, language, timezone, occupation)
-   - Call add_memory for facts that link the user to things or places (e.g. lives in Valencia → label='Valencia', relation='LIVES_IN'; likes X → relation='LIKES')
+   - Always pass for_user=<participant_name> (from the conversation's participantName field) to every add_memory, search_memory, and set_user_property call so that facts are stored under the correct user and not under a shared loopback user.
+   - Call set_user_property(..., for_user=<participant_name>) for the user's own attributes (real name, phone, birthday, language, timezone, occupation)
+   - Call add_memory(..., for_user=<participant_name>) for facts that link the user to things or places (e.g. lives in Valencia → label='Valencia', relation='LIVES_IN'; likes X → relation='LIKES')
    - Call add_user_relation when two users are related (e.g. friends → from_user, to_user, relation='FRIEND_OF')
    - Keep each fact independent (avoid intermediate nodes or grouping nodes)
 

--- a/apps/backend/internal/domain/services/mcp/internal_tools.go
+++ b/apps/backend/internal/domain/services/mcp/internal_tools.go
@@ -658,7 +658,8 @@ func (t *AddMemoryTool) Definition() ToolDefinition {
 			"properties": {
 				"content":  {"type": "string", "description": "Full sentence describing what to remember (e.g. 'User lives in Valencia', 'User loves electronic music')"},
 				"label":    {"type": "string", "description": "Short keyword for the fact (e.g. 'Valencia', 'Electronica', 'Software Engineer'). Defaults to first words of content."},
-				"relation": {"type": "string", "description": "Edge from user to this fact: LIVES_IN, LIKES, IS, WORKS_AT, WORKS_AS, PREFERS, HAS_FACT, etc. Defaults to HAS_FACT."}
+				"relation": {"type": "string", "description": "Edge from user to this fact: LIVES_IN, LIKES, IS, WORKS_AT, WORKS_AS, PREFERS, HAS_FACT, etc. Defaults to HAS_FACT."},
+				"for_user": {"type": "string", "description": "Name of the user this memory belongs to. Only for memory consolidation agents processing multiple users — omit for normal per-user interactions."}
 			},
 			"required": ["content"]
 		}`),
@@ -673,9 +674,13 @@ func (t *AddMemoryTool) Execute(ctx context.Context, params map[string]interface
 	label, _ := params["label"].(string)
 	relation, _ := params["relation"].(string)
 
-	// Prefer the display name (users.name) as the memory key when available.
+	// for_user allows consolidation agents to store facts for a specific user
+	// rather than the ambient context user (which is empty in loopback runs).
 	var userKey string
-	if dn, ok := ctx.Value(ContextKeyUserDisplayName).(string); ok && dn != "" {
+	if forUser, ok := params["for_user"].(string); ok && forUser != "" {
+		userKey = forUser
+	} else if dn, ok := ctx.Value(ContextKeyUserDisplayName).(string); ok && dn != "" {
+		// Prefer the display name (users.name) as the memory key when available.
 		userKey = dn
 	} else if u, ok := ctx.Value(contextKeyUserID).(string); ok {
 		userKey = u
@@ -787,8 +792,9 @@ func (t *SetUserPropertyTool) Definition() ToolDefinition {
 		InputSchema: json.RawMessage(`{
 			"type": "object",
 			"properties": {
-				"key": {"type": "string", "description": "Attribute name, snake_case (e.g. 'real_name', 'phone', 'birthday', 'preferred_language', 'timezone', 'occupation')"},
-				"value": {"type": "string", "description": "Attribute value as a string"}
+				"key":      {"type": "string", "description": "Attribute name, snake_case (e.g. 'real_name', 'phone', 'birthday', 'preferred_language', 'timezone', 'occupation')"},
+				"value":    {"type": "string", "description": "Attribute value as a string"},
+				"for_user": {"type": "string", "description": "Name of the user this property belongs to. Only for memory consolidation agents processing multiple users — omit for normal per-user interactions."}
 			},
 			"required": ["key", "value"]
 		}`),
@@ -802,9 +808,12 @@ func (t *SetUserPropertyTool) Execute(ctx context.Context, params map[string]int
 		return nil, fmt.Errorf("key is required")
 	}
 
-	// Prefer the display name (users.name) as the memory key when available.
+	// for_user allows consolidation agents to set properties for a specific user.
 	var userKey string
-	if dn, ok := ctx.Value(ContextKeyUserDisplayName).(string); ok && dn != "" {
+	if forUser, ok := params["for_user"].(string); ok && forUser != "" {
+		userKey = forUser
+	} else if dn, ok := ctx.Value(ContextKeyUserDisplayName).(string); ok && dn != "" {
+		// Prefer the display name (users.name) as the memory key when available.
 		userKey = dn
 	} else if u, ok := ctx.Value(contextKeyUserID).(string); ok {
 		userKey = u
@@ -831,7 +840,8 @@ func (t *SearchMemoryTool) Definition() ToolDefinition {
 		InputSchema: json.RawMessage(`{
 			"type": "object",
 			"properties": {
-				"query": {"type": "string", "description": "Topic or keyword to look up (e.g. 'music', 'work', 'language', 'hobbies')"}
+				"query":    {"type": "string", "description": "Topic or keyword to look up (e.g. 'music', 'work', 'language', 'hobbies')"},
+				"for_user": {"type": "string", "description": "Name of the user whose memory to search. Only for memory consolidation agents processing multiple users — omit for normal per-user interactions."}
 			},
 			"required": ["query"]
 		}`),
@@ -844,9 +854,12 @@ func (t *SearchMemoryTool) Execute(ctx context.Context, params map[string]interf
 		return nil, fmt.Errorf("query is required")
 	}
 
-	// Prefer display name as memory key when available.
+	// for_user allows consolidation agents to search memory for a specific user.
 	var userKey string
-	if dn, ok := ctx.Value(ContextKeyUserDisplayName).(string); ok && dn != "" {
+	if forUser, ok := params["for_user"].(string); ok && forUser != "" {
+		userKey = forUser
+	} else if dn, ok := ctx.Value(ContextKeyUserDisplayName).(string); ok && dn != "" {
+		// Prefer display name as memory key when available.
 		userKey = dn
 	} else if u, ok := ctx.Value(contextKeyUserID).(string); ok {
 		userKey = u

--- a/apps/backend/internal/infrastructure/adapters/memory/neo4j/adapter.go
+++ b/apps/backend/internal/infrastructure/adapters/memory/neo4j/adapter.go
@@ -48,7 +48,14 @@ func (a *Adapter) AddKnowledge(ctx context.Context, userID string, content strin
 	defer session.Close(context.Background())
 
 	if label == "" {
-		label = uuid.New().String()
+		words := strings.Fields(content)
+		if len(words) > 4 {
+			words = words[:4]
+		}
+		label = strings.Join(words, "_")
+		if label == "" {
+			label = uuid.New().String()
+		}
 	}
 	rel := relation
 	if rel == "" {
@@ -168,7 +175,7 @@ func (a *Adapter) GetUserGraph(ctx context.Context, userID string) (ports.Graph,
 	}
 
 	result, err := session.Run(ctx,
-		"MATCH (u:User {id: $userID})-[r]-(n) RETURN labels(n) AS labels, n.id AS id, n.content AS content, n.name AS name, n.label AS nodeLabel, type(r) AS relType",
+		"MATCH (u:User {id: $userID})-[r]-(n) RETURN labels(n) AS labels, n.id AS id, n.content AS content, n.name AS name, n.label AS nodeLabel, type(r) AS relType, properties(u) AS userProps, properties(n) AS nodeProps",
 		map[string]interface{}{"userID": userID},
 	)
 	if err != nil {
@@ -179,13 +186,21 @@ func (a *Adapter) GetUserGraph(ctx context.Context, userID string) (ports.Graph,
 	edges := make([]ports.GraphEdge, 0)
 
 	userNodeID := fmt.Sprintf("user:%s", userID)
-	nodes[userNodeID] = ports.GraphNode{ID: userNodeID, Label: userLabel, Type: "user", Value: userVal}
+	userNode := ports.GraphNode{ID: userNodeID, Label: userLabel, Type: "user", Value: userVal}
 
 	for result.Next(ctx) {
 		record := result.Record()
 		labels, _ := record.Get("labels")
 		id, _ := record.Get("id")
 		relType, _ := record.Get("relType")
+
+		// Populate user node properties from the first row that has them.
+		if _, exists := nodes[userNodeID]; !exists {
+			if up, ok := record.Get("userProps"); ok {
+				userNode.Properties = neo4jPropsToMap(up, "id", "displayName")
+			}
+			nodes[userNodeID] = userNode
+		}
 
 		if idVal, ok := id.(string); ok && idVal != "" {
 			typeStr := "Node"
@@ -205,10 +220,15 @@ func (a *Adapter) GetUserGraph(ctx context.Context, userID string) (ports.Graph,
 			} else if n, ok := record.Get("name"); ok && n != nil {
 				value = fmt.Sprintf("%v", n)
 			}
+			np, _ := record.Get("nodeProps")
 			// Use real Neo4j node id so GUI delete/update work.
-			nodes[idVal] = ports.GraphNode{ID: idVal, Label: displayLabel, Type: strings.ToLower(typeStr), Value: value}
+			nodes[idVal] = ports.GraphNode{ID: idVal, Label: displayLabel, Type: strings.ToLower(typeStr), Value: value, Properties: neo4jPropsToMap(np, "id", "displayName")}
 			edges = append(edges, ports.GraphEdge{Source: userNodeID, Target: idVal, Label: fmt.Sprintf("%v", relType)})
 		}
+	}
+	// Ensure user node is present even when there are no connected nodes.
+	if _, exists := nodes[userNodeID]; !exists {
+		nodes[userNodeID] = userNode
 	}
 
 	graphNodes := make([]ports.GraphNode, 0, len(nodes))
@@ -222,7 +242,7 @@ func (a *Adapter) GetUserGraph(ctx context.Context, userID string) (ports.Graph,
 // getFullGraph returns all User and Fact nodes with their relationships (dashboard full memory view).
 func (a *Adapter) getFullGraph(ctx context.Context, session neo4j.SessionWithContext) (ports.Graph, error) {
 	result, err := session.Run(ctx,
-		"MATCH (u:User)-[r]->(n) RETURN u.id AS userId, u.displayName AS userDisplayName, labels(n) AS labels, n.id AS id, n.content AS content, n.name AS name, n.label AS nodeLabel, n.displayName AS targetDisplayName, type(r) AS relType",
+		"MATCH (u:User)-[r]->(n) RETURN u.id AS userId, u.displayName AS userDisplayName, labels(n) AS labels, n.id AS id, n.content AS content, n.name AS name, n.label AS nodeLabel, n.displayName AS targetDisplayName, type(r) AS relType, properties(u) AS userProps, properties(n) AS nodeProps",
 		nil,
 	)
 	if err != nil {
@@ -251,7 +271,8 @@ func (a *Adapter) getFullGraph(ctx context.Context, session neo4j.SessionWithCon
 				userLabel = fmt.Sprintf("%v", dn)
 				userVal = userLabel
 			}
-			nodes[userNodeID] = ports.GraphNode{ID: userNodeID, Label: userLabel, Type: "user", Value: userVal}
+			up, _ := record.Get("userProps")
+			nodes[userNodeID] = ports.GraphNode{ID: userNodeID, Label: userLabel, Type: "user", Value: userVal, Properties: neo4jPropsToMap(up, "id", "displayName")}
 		}
 
 		if idVal, ok := id.(string); ok && idVal != "" {
@@ -277,8 +298,9 @@ func (a *Adapter) getFullGraph(ctx context.Context, session neo4j.SessionWithCon
 			} else if n, ok := record.Get("name"); ok && n != nil {
 				value = fmt.Sprintf("%v", n)
 			}
+			np, _ := record.Get("nodeProps")
 			// Use real Neo4j node id so GUI delete/update work.
-			nodes[idVal] = ports.GraphNode{ID: idVal, Label: displayLabel, Type: strings.ToLower(typeStr), Value: value}
+			nodes[idVal] = ports.GraphNode{ID: idVal, Label: displayLabel, Type: strings.ToLower(typeStr), Value: value, Properties: neo4jPropsToMap(np, "id", "displayName")}
 			edges = append(edges, ports.GraphEdge{Source: userNodeID, Target: idVal, Label: fmt.Sprintf("%v", relType)})
 		}
 	}
@@ -526,6 +548,32 @@ func (b *Neo4jMemoryBackend) GetRelatedEntities(ctx context.Context, entityID st
 		}
 	}
 	return entities, result.Err()
+}
+
+// neo4jPropsToMap converts the result of Cypher's properties(n) to a
+// map[string]string suitable for GraphNode.Properties, skipping any keys
+// listed in exclude (typically "id" and "displayName" which are already
+// surfaced as dedicated fields on GraphNode).
+func neo4jPropsToMap(raw interface{}, exclude ...string) map[string]string {
+	propsMap, ok := raw.(map[string]interface{})
+	if !ok || len(propsMap) == 0 {
+		return nil
+	}
+	skip := make(map[string]bool, len(exclude))
+	for _, k := range exclude {
+		skip[k] = true
+	}
+	result := make(map[string]string, len(propsMap))
+	for k, v := range propsMap {
+		if skip[k] || v == nil {
+			continue
+		}
+		result[k] = fmt.Sprintf("%v", v)
+	}
+	if len(result) == 0 {
+		return nil
+	}
+	return result
 }
 
 var _ ports.MemoryPort = (*Adapter)(nil)

--- a/apps/frontend/src/styles/global.css
+++ b/apps/frontend/src/styles/global.css
@@ -1,6 +1,8 @@
 /* Copyright (c) OpenLobster contributors. See LICENSE for details. */
 
 :root {
+  color-scheme: dark;
+
   /* Backgrounds — exact values from design guide */
   --color-bg-sunken:   #0a0a0a;  /* Header bar, deepest chrome */
   --color-bg-surface:  #0d0d0d;  /* Secondary panels */
@@ -99,6 +101,8 @@
 
 /* Light theme — overrides when data-theme="light" */
 [data-theme="light"] {
+  color-scheme: light;
+
   --color-bg-sunken:   #e8e8e8;
   --color-bg-surface:  #eeeeee;
   --color-bg-base:     #f5f5f5;

--- a/packages/ui/src/styles/tokens.css
+++ b/packages/ui/src/styles/tokens.css
@@ -8,6 +8,8 @@
  */
 
 :root {
+  color-scheme: dark;
+
   /* ─── Backgrounds (hierarchy by tonality — no borders) ─── */
   --color-bg-base:      #141414; /* Main content area */
   --color-bg-surface:   #0D0D0D; /* Header, footer */
@@ -104,8 +106,10 @@
   --ease-inout: cubic-bezier(0.4, 0, 0.2, 1);
 }
 
-/* Light theme (future) */
+/* Light theme */
 [data-theme="light"] {
+  color-scheme: light;
+
   --color-bg-base:        #FAFAFA;
   --color-bg-surface:     #F0F0F0;
   --color-bg-sunken:      #E8E8E8;


### PR DESCRIPTION
Two bugs caused the same fact (e.g. "Elche") to appear twice in the
memory dashboard:

1. Neo4j adapter used uuid.New() as the label when no label was
   provided, so the label-based deduplication check always missed the
   existing node and created a new one. Changed to build a content slug
   (first 4 words) matching the GML backend behaviour.

2. The memory consolidation agent (loopback) ran without a user context,
   so add_memory/search_memory/set_user_property all used an empty
   string as the user key. Facts were stored under a "" user node while
   the real user's facts were under their display name. The dashboard
   full-graph query (userID="*") showed both, giving duplicates.

   Fixed by adding an optional `for_user` parameter to add_memory,
   search_memory and set_user_property. The consolidation system prompt
   now instructs the agent to always pass for_user=<participant_name>
   so facts land under the correct user node.

https://claude.ai/code/session_01HKJa2RE9gLBA9aG3qXx5ob

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Memory operations are now user-scoped: facts and properties are stored and deduplicated per specific user when a target user is provided.
  * Graph views now include richer node and user properties, improving detail and accuracy in visualizations.

* **Style**
  * Added color-scheme support for dark and light themes to improve theme detection and switching.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->