### PR TITLE
fix: resolve Neo4j node props update failures and label leak in Facts

### DIFF
--- a/apps/backend/internal/infrastructure/adapters/memory/neo4j/adapter.go
+++ b/apps/backend/internal/infrastructure/adapters/memory/neo4j/adapter.go
@@ -241,7 +241,8 @@ func (a *Adapter) GetUserGraph(ctx context.Context, userID string) (ports.Graph,
 			}
 			np, _ := record.Get("nodeProps")
 			// Use real Neo4j node id so GUI delete/update work.
-			nodes[idVal] = ports.GraphNode{ID: idVal, Label: displayLabel, Type: strings.ToLower(typeStr), Value: value, Properties: neo4jPropsToMap(np, "id", "displayName")}
+			// Exclude "label" since it is already surfaced as the Label field on GraphNode.
+			nodes[idVal] = ports.GraphNode{ID: idVal, Label: displayLabel, Type: strings.ToLower(typeStr), Value: value, Properties: neo4jPropsToMap(np, "id", "displayName", "label")}
 			edges = append(edges, ports.GraphEdge{Source: userNodeID, Target: idVal, Label: fmt.Sprintf("%v", relType)})
 		}
 	}
@@ -319,7 +320,8 @@ func (a *Adapter) getFullGraph(ctx context.Context, session neo4j.SessionWithCon
 			}
 			np, _ := record.Get("nodeProps")
 			// Use real Neo4j node id so GUI delete/update work.
-			nodes[idVal] = ports.GraphNode{ID: idVal, Label: displayLabel, Type: strings.ToLower(typeStr), Value: value, Properties: neo4jPropsToMap(np, "id", "displayName")}
+			// Exclude "label" since it is already surfaced as the Label field on GraphNode.
+			nodes[idVal] = ports.GraphNode{ID: idVal, Label: displayLabel, Type: strings.ToLower(typeStr), Value: value, Properties: neo4jPropsToMap(np, "id", "displayName", "label")}
 			edges = append(edges, ports.GraphEdge{Source: userNodeID, Target: idVal, Label: fmt.Sprintf("%v", relType)})
 		}
 	}
@@ -410,11 +412,15 @@ func (a *Adapter) SetUserProperty(ctx context.Context, userID, key, value string
 	defer session.Close(ctx)
 
 	cypher := fmt.Sprintf(`MERGE (u:User {id: $userID}) SET u.%s = $value`, key)
-	_, err := session.Run(ctx, cypher, map[string]interface{}{
+	result, err := session.Run(ctx, cypher, map[string]interface{}{
 		"userID": userID,
 		"value":  value,
 	})
-	return err
+	if err != nil {
+		return err
+	}
+	result.Consume(ctx)
+	return nil
 }
 
 // EditMemoryNode updates the content (and optionally label) of a Fact node.
@@ -466,7 +472,7 @@ func (a *Adapter) DeleteMemoryNode(ctx context.Context, userID, nodeID string) e
 	return nil
 }
 
-// UpdateNode implements NodeMutatorPort for the dashboard: updates a Fact by id (content and optional label).
+// UpdateNode implements NodeMutatorPort for the dashboard: updates a Fact by id (content, optional label, and extra properties).
 // userID is not available in the dashboard flow; the adapter matches the Fact by id only.
 func (a *Adapter) UpdateNode(ctx context.Context, id, label, typ, value string, properties map[string]string) error {
 	a.mu.Lock()
@@ -482,6 +488,16 @@ func (a *Adapter) UpdateNode(ctx context.Context, id, label, typ, value string, 
 		cypher += ", f.label = $label"
 		params["label"] = label
 	}
+	// Apply extra properties from the map, skipping reserved/already-handled keys.
+	for k, v := range properties {
+		safe := sanitizePropKey(k)
+		if safe == "" || safe == "id" || safe == "content" || safe == "label" {
+			continue
+		}
+		paramKey := "prop_" + safe
+		cypher += fmt.Sprintf(", f.%s = $%s", safe, paramKey)
+		params[paramKey] = v
+	}
 	cypher += " RETURN f"
 	result, err := session.Run(ctx, cypher, params)
 	if err != nil {
@@ -492,6 +508,18 @@ func (a *Adapter) UpdateNode(ctx context.Context, id, label, typ, value string, 
 	}
 	result.Consume(ctx)
 	return nil
+}
+
+// sanitizePropKey returns a safe Cypher property key: starts with a letter, contains only
+// letters, digits, and underscores. Returns empty string if no valid characters remain.
+func sanitizePropKey(key string) string {
+	var b strings.Builder
+	for _, r := range key {
+		if (r >= 'a' && r <= 'z') || (r >= 'A' && r <= 'Z') || r == '_' || (b.Len() > 0 && r >= '0' && r <= '9') {
+			b.WriteRune(r)
+		}
+	}
+	return b.String()
 }
 
 // DeleteNode implements NodeMutatorPort for the dashboard: deletes a Fact by id (no userID in flow).


### PR DESCRIPTION
- SetUserProperty: add result.Consume() so the auto-commit transaction is actually committed (previously the write was silently rolled back when the session closed before the result was consumed)
- UpdateNode: apply the properties map parameter that was previously accepted but silently ignored, using sanitized property keys and parameterized values
- neo4jPropsToMap: exclude "label" key when building the Properties map for nodes, since it is already surfaced as the dedicated Label field on GraphNode and should not appear as a duplicate property entry

https://claude.ai/code/session_01GrqQ124JGjShYWKBjLH9AV

<!--
Please fill out this template to help reviewers quickly understand
what the PR changes and how to validate it. Project documentation
is English-first; a short Spanish note is provided below.
-->

## Summary

Provide a short description of the change and the reason for it.

## Related issues

- Fixes: A brief description of the issue, e.g. "Fixes updating the API endpoint to handle new parameters."

## Type of change
- [ ] Bugfix
- [ ] New feature
- [ ] Documentation
- [ ] Refactor
- [ ] Test-only change

## How to test / QA steps

Describe manual steps and automated commands to validate the change, e.g.

1. Install workspace dependencies: `pnpm install`
2. Build backend: `pnpm --filter @openlobster/backend build`
3. Build frontend: `pnpm --filter @openlobster/frontend build`
4. Run unit tests: `pnpm --filter @openlobster/frontend test` and `pnpm --filter @openlobster/backend test`
5. Lint: `pnpm --filter @openlobster/frontend lint` and `pnpm --filter @openlobster/backend lint`
6. Steps to reproduce the issue (if applicable)

## Checklist (required before merge)
- [ ] I have read the repository rules and contribution requirements
- [ ] All unit and integration tests pass locally and in CI
- [ ] The project builds without errors (frontend and backend)
- [ ] Linters and formatters pass (ESLint/Prettier, gofmt/golangci-lint)
- [ ] I updated user-facing documentation when applicable (docs/ or README)
- [ ] I did not add secrets or personal config files
- [ ] Database migrations added (if schema changes) and tested
- [ ] I added or updated tests for relevant changes

## Deployment notes / Rollback plan

Any special deployment steps, feature flags, or rollbacks.

## Notes for the reviewer

- Highlight non-obvious design decisions, API changes, or migration steps.

---

ES (resumen breve):

Incluye una descripción corta en español si quieres; la plantilla principal debe permanecer en inglés para la documentación del proyecto.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of property update operations to ensure proper completion.

* **New Features**
  * Added support for setting custom properties on graph nodes with automatic validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->