### PR TITLE
Potential fix for code scanning alert no. 7: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/tests.backend-ci.yaml
+++ b/.github/workflows/tests.backend-ci.yaml
@@ -12,6 +12,9 @@ on:
       - 'apps/backend/**'
       - '.github/workflows/tests.backend-ci.yaml'
 
+permissions:
+  contents: read
+
 defaults:
   run:
     working-directory: apps/backend


### PR DESCRIPTION
Potential fix for [https://github.com/Neirth/OpenLobster/security/code-scanning/7](https://github.com/Neirth/OpenLobster/security/code-scanning/7)

In general, the fix is to add an explicit `permissions` block that restricts the `GITHUB_TOKEN` to the least privileges required. For this workflow, all jobs only need to read repository contents (to run `actions/checkout` and Go tooling) and upload artifacts; they do not modify repo contents or PRs. Therefore, `contents: read` at the workflow root is sufficient and aligns with the suggested minimal starting point. Placing it at the root applies to all jobs uniformly and avoids duplication.

Concretely, in `.github/workflows/tests.backend-ci.yaml`, add a `permissions:` block after the `on:` section and before `defaults:`. This will ensure that `GITHUB_TOKEN` used by all jobs (`lint`, `unit-tests`, `integration-tests`, `build`) is limited to read-only repo access. No additional imports, methods, or other definitions are needed because this is purely a GitHub Actions YAML configuration change. Existing functionality (linting, testing, building, artifact upload) will remain unaffected, as none of those require write permissions.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated GitHub Actions workflow configuration for backend testing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->